### PR TITLE
Fixed warnings treated as errors when building on Linux (G++)

### DIFF
--- a/source-profiler.cpp
+++ b/source-profiler.cpp
@@ -6,7 +6,6 @@
 #include <QAction>
 #include <QMainWindow>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
 #include <QCheckBox>
@@ -75,17 +74,17 @@ OBSPerfViewer::OBSPerfViewer(QWidget *parent) : QDialog(parent)
 	connect(tvh, &QHeaderView::customContextMenuRequested, this, [&](const QPoint &pos) {
 		UNUSED_PARAMETER(pos);
 		QMenu menu;
-		auto tvh = treeView->header();
-		for (int i = 0; i < tvh->count(); i++) {
+		auto tvh2 = treeView->header();
+		for (int i = 0; i < tvh2->count(); i++) {
 			auto title = model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
 			auto a = menu.addAction(title);
 			a->setEnabled(i != 0);
 			a->setCheckable(true);
-			a->setChecked(!tvh->isSectionHidden(i));
+			a->setChecked(!tvh2->isSectionHidden(i));
 			connect(a, &QAction::triggered, [this, i] {
-				auto tvh = treeView->header();
-				tvh->setSectionHidden(i, !tvh->isSectionHidden(i));
-				if (!tvh->isSectionHidden(i))
+				auto tvh3 = treeView->header();
+				tvh3->setSectionHidden(i, !tvh3->isSectionHidden(i));
+				if (!tvh3->isSectionHidden(i))
 					treeView->resizeColumnToContents(i);
 			});
 		}
@@ -176,7 +175,7 @@ OBSPerfViewer::OBSPerfViewer(QWidget *parent) : QDialog(parent)
 #endif
 
 	auto obs_config = obs_frontend_get_user_config();
-	auto show_mode = config_get_int(obs_config, "PerfViewer", "showmode");
+	auto show_mode = (int)config_get_int(obs_config, "PerfViewer", "showmode");
 	config_set_default_bool(obs_config, "PerfViewer", "active", true);
 	bool active_only = config_get_bool(obs_config, "PerfViewer", "active");
 	model->setActiveOnly(active_only, false);
@@ -1158,18 +1157,18 @@ PerfTreeItem *PerfTreeItem::child(int row) const
 
 int PerfTreeItem::childCount() const
 {
-	return m_childItems.count();
+	return (int)(m_childItems.count());
 }
 
 int PerfTreeItem::columnCount() const
 {
-	return m_model->columnCount();
+	return (int)(m_model->columnCount());
 }
 
 int PerfTreeItem::row() const
 {
 	if (m_parentItem)
-		return m_parentItem->m_childItems.indexOf(const_cast<PerfTreeItem *>(this));
+		return (int)(m_parentItem->m_childItems.indexOf(const_cast<PerfTreeItem *>(this)));
 
 	return 0;
 }
@@ -1356,5 +1355,5 @@ void PerfTreeModel::itemChanged(PerfTreeItem *item)
 
 void PerfTreeModel::setRefreshInterval(int interval)
 {
-	refreshInterval = interval;
+	refreshInterval = (unsigned int)interval;
 }

--- a/source-profiler.hpp
+++ b/source-profiler.hpp
@@ -113,7 +113,7 @@ private:
 	bool activeOnly = true;
 	bool refreshing = false;
 	double frameTime = 0.0;
-	int refreshInterval = 1000;
+	unsigned int refreshInterval = 1000;
 
 	static bool EnumAll(void *data, obs_source_t *source);
 	static bool EnumNotPrivateSource(void *data, obs_source_t *source);


### PR DESCRIPTION
Adapted the code to use explicit casts and use different variable names to avoid conflicts.

This is to avoid warnings from G++ that are treated as errors.

No feature added, this should not pose any issue in the main codebase, even under Windows or MacOS.

I'm able to build for Linux locally after this fix.

---------------------

<details>
    <summary>For reference, the errors I got without this fix: (click to expand)</summary>
    
    /obs-source-profiler/source-profiler.cpp: In lambda function:
    /obs-source-profiler/source-profiler.cpp:78:22: error: declaration of ‘tvh’ shadows a previous local [-Werror=shadow]
       78 |                 auto tvh = treeView->header();
          |                      ^~~
    /obs-source-profiler/source-profiler.cpp:65:14: note: shadowed declaration is here
       65 |         auto tvh = treeView->header();
          |              ^~~
    /obs-source-profiler/source-profiler.cpp: In lambda function:
    /obs-source-profiler/source-profiler.cpp:86:38: error: declaration of ‘tvh’ shadows a previous local [-Werror=shadow]
       86 |                                 auto tvh = treeView->header();
          |                                      ^~~
    /obs-source-profiler/source-profiler.cpp:78:22: note: shadowed declaration is here
       78 |                 auto tvh = treeView->header();
          |                      ^~~
    /obs-source-profiler/source-profiler.cpp: In constructor ‘OBSPerfViewer::OBSPerfViewer(QWidget*)’:
    /obs-source-profiler/source-profiler.cpp:191:37: error: conversion from ‘long int’ to ‘int’ may change value [-Werror=conversion]
      191 |         groupByBox->setCurrentIndex(show_mode);
          |                                     ^~~~~~~~~
    /obs-source-profiler/source-profiler.cpp: In member function ‘int PerfTreeItem::childCount() const’:
    /obs-source-profiler/source-profiler.cpp:1161:34: error: conversion from ‘qsizetype’ {aka ‘long long int’} to ‘int’ may change value [-Werror=conversion]
     1161 |         return m_childItems.count();
          |                ~~~~~~~~~~~~~~~~~~^~
    /obs-source-profiler/source-profiler.cpp: In member function ‘int PerfTreeItem::row() const’:
    /obs-source-profiler/source-profiler.cpp:1172:58: error: conversion from ‘qsizetype’ {aka ‘long long int’} to ‘int’ may change value [-Werror=conversion]
     1172 |                 return m_parentItem->m_childItems.indexOf(const_cast<PerfTreeItem *>(this));
          |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
</details>