### PR TITLE
Fix occasional "QThread: Destroyed while thread is still running" on Profiler window close

### DIFF
--- a/source-profiler.hpp
+++ b/source-profiler.hpp
@@ -109,6 +109,7 @@ private:
 	PerfTreeItem *rootItem = nullptr;
 	QList<PerfTreeColumn> columns;
 	std::unique_ptr<QThread> updater;
+	bool updaterRunning;
 
 	enum ShowMode showMode = ShowMode::SCENE;
 	bool activeOnly = true;


### PR DESCRIPTION
Sometimes, closing the Profiler window crashes OBS, showing in the logs "QThread: Destroyed while thread is still running".

This mostly happen under Linux. It appears that the thread management is mostly different accross OSes.

After investigation, it seems that the `PerfTreeModel::updater` thread, and the use of `terminate()` are the root causes. 

This fix adds a `PerfTreeModel::updaterRunning` boolean, and replaces the `while(true)` in the updater by `while(updaterRunning)`. 
The destructor of `PerfTreeModel` can now gracefully terminate the thread by setting `PerfTreeModel::updaterRunning` to `false`, then wait for it to terminate gracefully.  
If, for some reason, the updater takes more than 1s to end, `terminate()` is used as a fallback.

NOTE: this PR is based on the PR #5, since I needed those changes to compile and test the fix.